### PR TITLE
Re-add Offline Maps

### DIFF
--- a/Cirque/Cirque.xcodeproj/project.pbxproj
+++ b/Cirque/Cirque.xcodeproj/project.pbxproj
@@ -23,7 +23,7 @@
 		D897D63B2BF30FA600027155 /* CirqueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D897D63A2BF30FA600027155 /* CirqueTests.swift */; };
 		D897D6452BF30FA600027155 /* CirqueUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D897D6442BF30FA600027155 /* CirqueUITests.swift */; };
 		D897D6472BF30FA600027155 /* CirqueUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D897D6462BF30FA600027155 /* CirqueUITestsLaunchTests.swift */; };
-		D89ABD0B2C0987B10029C444 /* OfflineMapDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89ABD0A2C0987B10029C444 /* OfflineMapDownloader.swift */; };
+		D89ABD0B2C0987B10029C444 /* OfflineMaps.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89ABD0A2C0987B10029C444 /* OfflineMaps.swift */; };
 		D8BD608C2BF313130011C7C2 /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8BD608B2BF313130011C7C2 /* MapView.swift */; };
 		D8BD608E2BF313B80011C7C2 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8BD608D2BF313B80011C7C2 /* AboutView.swift */; };
 		D8C83DC42C04C76E00F6221F /* CircuitNavButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C83DC32C04C76E00F6221F /* CircuitNavButtons.swift */; };
@@ -70,7 +70,7 @@
 		D897D6442BF30FA600027155 /* CirqueUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CirqueUITests.swift; sourceTree = "<group>"; };
 		D897D6462BF30FA600027155 /* CirqueUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CirqueUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		D898448A2BF461330049196B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		D89ABD0A2C0987B10029C444 /* OfflineMapDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineMapDownloader.swift; sourceTree = "<group>"; };
+		D89ABD0A2C0987B10029C444 /* OfflineMaps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineMaps.swift; sourceTree = "<group>"; };
 		D8BD608B2BF313130011C7C2 /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 		D8BD608D2BF313B80011C7C2 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		D8C83DC32C04C76E00F6221F /* CircuitNavButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircuitNavButtons.swift; sourceTree = "<group>"; };
@@ -112,7 +112,7 @@
 				D86792BA2BF8F0160006405C /* MapViewModel.swift */,
 				D890D0942BFB901900C94EA7 /* LocateMeButton.swift */,
 				D8C83DC32C04C76E00F6221F /* CircuitNavButtons.swift */,
-				D89ABD0A2C0987B10029C444 /* OfflineMapDownloader.swift */,
+				D89ABD0A2C0987B10029C444 /* OfflineMaps.swift */,
 				D8D8C01D2C1C67C60072357F /* MapUtilities.swift */,
 				D8D8C01F2C1E21A00072357F /* MapEnv.swift */,
 			);
@@ -360,7 +360,7 @@
 				D87FB0772C0258B00072D028 /* LineCapShape.swift in Sources */,
 				D8C83DC42C04C76E00F6221F /* CircuitNavButtons.swift in Sources */,
 				D8D8C0202C1E21A00072357F /* MapEnv.swift in Sources */,
-				D89ABD0B2C0987B10029C444 /* OfflineMapDownloader.swift in Sources */,
+				D89ABD0B2C0987B10029C444 /* OfflineMaps.swift in Sources */,
 				D890D0952BFB901900C94EA7 /* LocateMeButton.swift in Sources */,
 				D897D6272BF30FA300027155 /* ContentView.swift in Sources */,
 				D86792BF2BF8F0A20006405C /* ProblemView.swift in Sources */,

--- a/Cirque/Cirque.xcodeproj/xcuserdata/nathan.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Cirque/Cirque.xcodeproj/xcuserdata/nathan.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   uuid = "83B9406E-8662-45EF-A615-2CD81019019A"
+   type = "1"
+   version = "2.0">
+</Bucket>

--- a/Cirque/Cirque/AboutView.swift
+++ b/Cirque/Cirque/AboutView.swift
@@ -24,13 +24,13 @@ struct BulletText: View {
 }
 
 struct AboutView: View {
-    @StateObject private var offlineMapDownloader = OfflineMapDownloader()
+    @StateObject private var offlineMaps = OfflineMaps()
     
     let gitHubText = "The code for this project can be found at [GitHub](https://github.com/nathan-hadley/cirque-ios)."
     let circuits = [
         "Forestland Blue Circuit (V0-2)",
         "Swiftwater Red Circuit (V0-3)",
-        "Forestland Black Circuit (V3-5)",
+        "Forestland Black Circuit (V2-5)",
         "Straightaways White Circuit (V4-9)"
     ]
     
@@ -48,43 +48,48 @@ struct AboutView: View {
                         BulletText(text: circuit)
                     }
                     
-                    Text("If you're a developer, please reach out about contributing. If you're not a developer but want to help, please also reach out. Collecting all the information to add a new circuit takes time!")
+                    Text("If you're a developer, please reach out about contributing. If you're not a developer but want to help, please also reach out me at @nathanhadley_ on Instagram or Threads. Collecting all the information to add a new circuit takes time and I could use help!")
                     
                     Text(.init(gitHubText))
                     
-                    Text("How to Use")
+                    Text("Download Maps")
                         .font(.title)
                         .padding(.top, 20)
                     
-                    Text("The app caches map data after viewing for an undetermined amount of time. To ensure circuits show up without network connection, zoom in to the circuit you want to climb before going into the canyon. Stable offline access will be added soon.")
+                    Text("The app caches map data after viewing for an undetermined amount of time. To ensure circuits show up without network connection, download for offline use. If one of the circuits listed above is missing, try updating the map.")
                         .padding(.bottom, 20)
                     
-                    Text("Download Maps for Offline Use")
-                        .font(.title)
-                        .padding(.top, 20)
-                    
-                    if let successMessage = offlineMapDownloader.successMessage {
-                        Text(successMessage)
+                    if !offlineMaps.successMessage.isEmpty {
+                        Text(offlineMaps.successMessage)
                             .padding()
                             .background(Color.green)
                             .foregroundColor(Color.white)
                             .cornerRadius(4)
                     }
                     
-                    if let errorMessage = offlineMapDownloader.errorMessage {
-                        Text(errorMessage)
+                    if !offlineMaps.errorMessage.isEmpty {
+                        Text(offlineMaps.errorMessage)
                             .padding()
                             .background(Color.red)
                             .foregroundColor(Color.white)
                             .cornerRadius(4)
                     }
                     
-                    Button(action: offlineMapDownloader.updateMapData) {
-                        Text(offlineMapDownloader.mapDownloaded ? "Update Map" : "Download Map")
-                            .padding()
-                            .background(Color.blue)
-                            .foregroundColor(Color.white)
-                            .cornerRadius(8)
+                    if offlineMaps.loading {
+                        VStack {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle(tint: .blue))
+                                .scaleEffect(2)
+                                .padding()
+                        }
+                    } else {
+                        Button(action: offlineMaps.updateMapData) {
+                            Text(offlineMaps.mapDownloaded ? "Update Map" : "Download Map")
+                                .padding()
+                                .background(Color.blue)
+                                .foregroundColor(Color.white)
+                                .cornerRadius(8)
+                        }
                     }
                 }
                 .padding(.horizontal)

--- a/Cirque/Cirque/AboutView.swift
+++ b/Cirque/Cirque/AboutView.swift
@@ -24,6 +24,8 @@ struct BulletText: View {
 }
 
 struct AboutView: View {
+    @StateObject private var offlineMapDownloader = OfflineMapDownloader()
+    
     let gitHubText = "The code for this project can be found at [GitHub](https://github.com/nathan-hadley/cirque-ios)."
     let circuits = [
         "Forestland Blue Circuit (V0-2)",
@@ -56,8 +58,37 @@ struct AboutView: View {
                     
                     Text("The app caches map data after viewing for an undetermined amount of time. To ensure circuits show up without network connection, zoom in to the circuit you want to climb before going into the canyon. Stable offline access will be added soon.")
                         .padding(.bottom, 20)
+                    
+                    Text("Download Maps for Offline Use")
+                        .font(.title)
+                        .padding(.top, 20)
+                    
+                    if let successMessage = offlineMapDownloader.successMessage {
+                        Text(successMessage)
+                            .padding()
+                            .background(Color.green)
+                            .foregroundColor(Color.white)
+                            .cornerRadius(4)
+                    }
+                    
+                    if let errorMessage = offlineMapDownloader.errorMessage {
+                        Text(errorMessage)
+                            .padding()
+                            .background(Color.red)
+                            .foregroundColor(Color.white)
+                            .cornerRadius(4)
+                    }
+                    
+                    Button(action: offlineMapDownloader.updateMapData) {
+                        Text(offlineMapDownloader.mapDownloaded ? "Update Map" : "Download Map")
+                            .padding()
+                            .background(Color.blue)
+                            .foregroundColor(Color.white)
+                            .cornerRadius(8)
+                    }
                 }
                 .padding(.horizontal)
+                .padding(.bottom)
             }
         }
         .navigationBarTitle("About", displayMode: .inline)

--- a/Cirque/Cirque/Map/MapView.swift
+++ b/Cirque/Cirque/Map/MapView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct MapView: View {
     @StateObject private var mapViewModel = MapViewModel()
     @State private var map: MapboxMap?
-    let offlineMapDownloader = OfflineMapDownloader()
+    let offlineMapDownloader = OfflineMaps()
     
     private var gestureOptions: GestureOptions {
         var options = GestureOptions()


### PR DESCRIPTION
Adding this functionality back in after removing due to inconsistent behavior. Instead of downloading or updating on app init, the user has control to manage downloading in the About view.